### PR TITLE
travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
-  local_dir: /tmp/output
+  local_dir: $TRAVIS_BUILD_DIR/tmp/output
   on:
     all_branches: true


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/deployment/pages/:
local-dir: Directory to push to GitHub Pages, relative to the current
directory, defaults to the current directory (example:
your_build_folder)