### PR TITLE
Revert "travis-ci"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
-  local_dir: $TRAVIS_BUILD_DIR/tmp/output
+  local_dir: /tmp/output
   on:
     all_branches: true


### PR DESCRIPTION
_rsync: change_dir "/home/travis/build/LCTT/LFS-BOOK/home/travis/build/LCTT/LFS-BOOK/tmp/output" failed: No such file or directory (2)_
根据 error 信息回退 #90 的变更
This reverts commit ca1b7e657ea714de16a2e7b777aa813d1d334310.